### PR TITLE
HIVE-3694: Add targets to generate hive-exec-test jar needed for testing Shark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build
+/build
 build-eclipse
 .arc_jira_lib
 .classpath*

--- a/bin/build/add_dependency_to_pom.py
+++ b/bin/build/add_dependency_to_pom.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+# Add
+import sys
+import os
+
+args = sys.argv[1:]
+
+if len(args) != 5:
+  print >> sys.stderr, "Arguments: fileName groupId artifactId version scope"
+  print >> sys.stderr, "Provided arguments: " + " ".join(args)
+  sys.exit(1)
+
+fileName, groupId, artifactId, version, scope = args
+f = open(fileName)
+lines = [l for l in f]
+f.close()
+
+f = open(fileName, "wt")
+for l in lines:
+  l = l.rstrip()
+  l_trim = l.strip()
+  if l_trim == "</dependencies>":
+    print >> f, """
+    <dependency>
+      <groupId>%s</groupId>
+      <artifactId>%s</artifactId>
+      <version>%s</version>
+      <scope>%s</scope>
+    </dependency>
+""" % (groupId, artifactId, version, scope)
+  print >> f, l
+
+f.close()
+
+print "Added dependency to %s: %s:%s:%s:%s" % (fileName, groupId, artifactId,
+    version, scope)

--- a/build-common.xml
+++ b/build-common.xml
@@ -68,7 +68,7 @@
 
   <property name="hadoop.opts.23" value="-D mapreduce.framework.name=local" />
   <property name="hadoop.opts.20" value="" />
-  
+
   <path id="test.classpath">
     <pathelement location="${test.build.classes}" />
     <pathelement location="${test.build.resources}" />
@@ -177,7 +177,7 @@
     <pathelement location="${build.dir.hive}/classes"/>
     <fileset dir="${build.dir.hive}" includes="*/*.jar"/>
     <fileset dir="${hive.root}/lib" includes="*.jar"/>
-    <fileset dir="${build.ivy.lib.dir}/default" includes="*.jar" 
+    <fileset dir="${build.ivy.lib.dir}/default" includes="*.jar"
              erroronmissingdir="false"/>
   </path>
 
@@ -383,7 +383,7 @@
     </if>
     <if>
       <equals arg1="${test.print.classpath}" arg2="true" />
-      <then>        
+      <then>
         <echo message="Test Classpath: ${hadoop.testcp}"/>
       </then>
     </if>
@@ -417,6 +417,7 @@
       <sysproperty key="derby.version" value="${derby.version}"/>
       <sysproperty key="hive.version" value="${version}"/>
       <sysproperty key="hadoop.bin.path" value="${test.hadoop.bin.path}"/>
+      <jvmarg value="-XX:-UseSplitVerifier"/>
 
       <classpath refid="test.local.classpath"/>
       <formatter type="${test.junit.output.format}" usefile="${test.junit.output.usefile}" />

--- a/build.xml
+++ b/build.xml
@@ -124,6 +124,18 @@
     </sequential>
   </macrodef>
 
+  <macrodef name="iterate-test-subset">
+    <attribute name="target"/>
+    <attribute name="filelist"/>
+    <sequential>
+      <subant target="@{target}">
+        <property name="thrift.home" value="${thrift.home}"/>
+        <property name="build.dir.hive" location="${build.dir.hive}"/>
+        <filelist dir="." files="@{filelist}"/>
+      </subant>
+    </sequential>
+  </macrodef>
+
   <macrodef name="iterate-thriftif">
     <attribute name="target"/>
     <sequential>
@@ -306,6 +318,14 @@
           description="Build Java test artifacts">
     <echo message="Project: ${ant.project.name}"/>
     <iterate-test target="compile-test"/>
+  </target>
+
+  <target name="hive-exec-test-jar" depends="jar"
+          description="Build Java test artifacts for QL">
+    <echo message="Project: ${ant.project.name}"/>
+    <iterate-test-subset filelist="ql/build.xml" target="gen-test"/>
+    <iterate-test-subset filelist="ql/build.xml" target="compile-test"/>
+    <iterate-test-subset filelist="ql/build.xml" target="test-jar"/>
   </target>
 
   <target name="test" depends="clean-test,jar-test" description="Run tests">

--- a/metastore/build.xml
+++ b/metastore/build.xml
@@ -103,7 +103,7 @@
           <path refid="classpath"/>
           <pathelement path="${build.dir}/classes/"/>
 	</classpath>
-	<jvmarg line="-Dlog4j.configuration=${basedir}/../conf/hive-log4j.properties"/>
+	<jvmarg line="-XX:-UseSplitVerifier -Dlog4j.configuration=${basedir}/../conf/hive-log4j.properties"/>
     </datanucleusenhancer>
   </target>
 

--- a/ql/build.xml
+++ b/ql/build.xml
@@ -219,6 +219,47 @@
                  artifactspattern="${build.dir}/${ivy.publish.pattern}"/>
   </target>
 
+  <target name="test-jar" depends="jar,gen-test">
+    <!-- Added to package test code for Shark project testing -->
+    <jar jarfile="${build.dir}/hive-exec-test-${version}.jar">
+      <fileset dir="${build.dir.hive}/common/test/classes" includes="**/*.class"/>
+      <fileset dir="${build.dir.hive}/ql/test/classes" includes="**/*.class,**/*.properties"/>
+      <fileset dir="${build.dir.hive}/serde/test/classes" includes="**/*.class"/>
+      <fileset dir="${build.dir.hive}/shims/test/classes" includes="**/*.class"/>
+      <manifest>
+        <!-- Not putting these in their own manifest section, since that inserts
+             a new-line, which breaks the reading of the attributes. -->
+        <attribute name="Implementation-Title" value="Hive"/>
+        <attribute name="Implementation-Version" value="${version}"/>
+        <attribute name="Implementation-Vendor" value="Apache"/>
+      </manifest>
+      <metainf dir="${hive.root}" includes="LICENSE,NOTICE"/>
+    </jar>
+    <ivy:makepom ivyfile="ivy.xml"
+        pomfile="${build.dir}/hive-exec-test-${version}.pom">
+       <mapping conf="default" scope="compile"/>
+       <mapping conf="compile" scope="compile"/>
+       <mapping conf="test" scope="test"/>
+     </ivy:makepom>
+     <!-- Add HBase as a test dependency (needed for mini ZK cluster). -->
+     <exec executable="${basedir}/../bin/build/add_dependency_to_pom.py" >
+       <arg value="${build.dir}/hive-exec-test-${version}.pom" />
+       <arg value="org.apache.hbase" />
+       <arg value="hbase" />
+       <arg value="${hbase.version}" />
+       <arg value="test" />
+     </exec>
+     <exec executable="mvn">
+       <arg value="install:install-file" />
+       <arg value="-Dfile=${build.dir}/hive-exec-test-${version}.jar" />
+       <arg value="-DpomFile=${build.dir}/hive-exec-test-${version}.pom" />
+       <arg value="-DgroupId=org.apache.hive" />
+       <arg value="-DartifactId=hive-exec-test" />
+       <arg value="-Dversion=${version}" />
+       <arg value="-Dpackaging=jar" />
+     </exec>
+  </target>
+
   <!-- Override deploy since we are deploying hive_exec and not hive_ql -->
   <target name="deploy" depends="jar">
     <echo message="${ant.project.name}"/>


### PR DESCRIPTION
This is needed as a prerequisite for Shark conversion to Maven. The hive-exec-test-0.9.0.jar is created and installed into the local Maven repository automatically when running "ant hive-exec-test-jar".

Also using SplitVerifier to avoid JDK 7 bytecode verification errors.
