### PR TITLE
Proper error handling in add_dependency_to_pom.py

### DIFF
--- a/bin/build/add_dependency_to_pom.py
+++ b/bin/build/add_dependency_to_pom.py
@@ -16,6 +16,7 @@ f = open(fileName)
 lines = [l for l in f]
 f.close()
 
+added_dependency = False
 f = open(fileName, "wt")
 for l in lines:
   l = l.rstrip()
@@ -29,9 +30,14 @@ for l in lines:
       <scope>%s</scope>
     </dependency>
 """ % (groupId, artifactId, version, scope)
+    added_dependency = True
   print >> f, l
 
 f.close()
+
+if not added_dependency:
+  print >> sys.stderr, "Failed to add dependency to %s" % fileName
+  sys.exit(1)
 
 print "Added dependency to %s: %s:%s:%s:%s" % (fileName, groupId, artifactId,
     version, scope)

--- a/ql/build.xml
+++ b/ql/build.xml
@@ -237,27 +237,27 @@
     </jar>
     <ivy:makepom ivyfile="ivy.xml"
         pomfile="${build.dir}/hive-exec-test-${version}.pom">
-       <mapping conf="default" scope="compile"/>
-       <mapping conf="compile" scope="compile"/>
-       <mapping conf="test" scope="test"/>
-     </ivy:makepom>
-     <!-- Add HBase as a test dependency (needed for mini ZK cluster). -->
-     <exec executable="${basedir}/../bin/build/add_dependency_to_pom.py" >
-       <arg value="${build.dir}/hive-exec-test-${version}.pom" />
-       <arg value="org.apache.hbase" />
-       <arg value="hbase" />
-       <arg value="${hbase.version}" />
-       <arg value="test" />
-     </exec>
-     <exec executable="mvn">
-       <arg value="install:install-file" />
-       <arg value="-Dfile=${build.dir}/hive-exec-test-${version}.jar" />
-       <arg value="-DpomFile=${build.dir}/hive-exec-test-${version}.pom" />
-       <arg value="-DgroupId=org.apache.hive" />
-       <arg value="-DartifactId=hive-exec-test" />
-       <arg value="-Dversion=${version}" />
-       <arg value="-Dpackaging=jar" />
-     </exec>
+      <mapping conf="default" scope="compile"/>
+      <mapping conf="compile" scope="compile"/>
+      <mapping conf="test" scope="test"/>
+    </ivy:makepom>
+    <!-- Add HBase as a test dependency (needed for mini ZK cluster). -->
+    <exec executable="${basedir}/../bin/build/add_dependency_to_pom.py" >
+      <arg value="${build.dir}/hive-exec-test-${version}.pom" />
+      <arg value="org.apache.hbase" />
+      <arg value="hbase" />
+      <arg value="${hbase.version}" />
+      <arg value="test" />
+    </exec>
+    <exec executable="mvn">
+      <arg value="install:install-file" />
+      <arg value="-Dfile=${build.dir}/hive-exec-test-${version}.jar" />
+      <arg value="-DpomFile=${build.dir}/hive-exec-test-${version}.pom" />
+      <arg value="-DgroupId=org.apache.hive" />
+      <arg value="-DartifactId=hive-exec-test" />
+      <arg value="-Dversion=${version}" />
+      <arg value="-Dpackaging=jar" />
+    </exec>
   </target>
 
   <!-- Override deploy since we are deploying hive_exec and not hive_ql -->


### PR DESCRIPTION
Return non-zero exit code in bin/build/add_dependency_to_pom.py If could not add dependency before the </dependencies> tag.
