### PR TITLE
Shark 0.9 fix Hive JDBC on JDK7 and add an ant target to build a debian package

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -58,6 +58,11 @@
   <property name="rat.build.dir" location="${build.dir.hive}/rat"/>
   <property name="md5sum.format" value="{0}  {1}"/>
 
+  <property name="deb.control.dir" location="${hive.root}/deb"/>
+  <property name="deb.build.dir" location="${hive.root}/build"/>
+  <property name="deb.control.build.dir" location="${deb.build.dir}/deb"/>
+  <property name="deb.prefix" value="/usr/share/${final.name}"/>
+
   <!-- Ignore Postgres upgrade scripts unless 'include.postgres' is true -->
   <condition property="metastore.excludes"
              value="${vcs.excludes}" else="${vcs.excludes},**/postgres/**">
@@ -678,7 +683,8 @@
     <antcall target="docs-anakia"/>
   </target>
 
-  <target name="javadoc" depends="package" description="Generate Javadoc">
+  <target name="javadoc" depends="package" description="Generate Javadoc"
+      unless="skip.javadoc">
     <echo message="Project: ${ant.project.name}"/>
     <mkdir dir="${build.javadoc}"/>
     <javadoc
@@ -799,6 +805,42 @@
     </macro_tar>
   </target>
 
+  <!-- ================================================================== -->
+  <!-- Debian packaging                                                   -->
+  <!-- ================================================================== -->
+
+  <target name="ivy-resolve-deb" depends="ivy-init-settings">
+    <echo message="Project: ${ant.project.name}"/>
+    <ivy:resolve settingsRef="${ant.project.name}.ivy.settings" conf="deb"
+                 log="${ivyresolvelog}"/>
+  </target>
+
+  <target name="ivy-retrieve-deb" depends="ivy-resolve-deb"
+    description="Retrieve Ivy-managed artifacts for Debian packaging">
+    <echo message="Project: ${ant.project.name}"/>
+    <ivy:retrieve settingsRef="${ant.project.name}.ivy.settings"
+      pattern="${build.ivy.lib.dir}/${ivy.artifact.retrieve.pattern}"
+      log="${ivyresolvelog}"/>
+    <ivy:cachepath pathid="deb-classpath" conf="deb"/>
+  </target>
+
+  <target name="deb" depends="binary,ivy-resolve-deb,ivy-retrieve-deb">
+    <copy todir="${deb.control.build.dir}">
+      <fileset dir="${deb.control.dir}"/>
+      <filterset begintoken="[[" endtoken="]]">
+        <filter token="version" value="${version}"/>
+      </filterset>
+    </copy>
+    <taskdef name="deb" classname="org.vafer.jdeb.ant.DebAntTask">
+      <classpath refid="deb-classpath"/>
+    </taskdef>
+    <deb destfile="${deb.build.dir}/${bin.final.name}.deb"
+        control="${deb.control.build.dir}">
+      <data src="${build.dir.hive}/${bin.final.name}.tar.gz" type="archive">
+        <mapper type="perm" strip="1" prefix="${deb.prefix}"/>
+      </data>
+    </deb>
+  </target>
 
   <!-- ================================================================== -->
   <!-- RAT                                                                -->

--- a/deb/control
+++ b/deb/control
@@ -1,0 +1,8 @@
+Package: hive-bin
+Version: [[version]]
+Section: misc
+Priority: extra
+Architecture: all
+Description: Apache Hive binary distribution, exactly the same as the tarball
+Distribution: development
+Maintainer: user@hive.apache.org

--- a/ivy.xml
+++ b/ivy.xml
@@ -29,6 +29,7 @@
     <conf name="checkstyle" visibility="private"/>
     <conf name="rat" visibility="private"/>
     <conf name="maven" visibility="private"/>
+    <conf name="deb" visibility="private"/>
   </configurations>
 
 
@@ -43,7 +44,8 @@
      conf="docs->default"/>
    <dependency org="org.apache.maven" name="maven-ant-tasks" rev="${maven-ant-tasks.version}"
      conf="maven->default"/>
+   <dependency org="org.vafer" name="jdeb" rev="${jdeb.version}" conf="deb->default" />
    <conflict manager="all" />
   </dependencies>
-  
+
 </ivy-module>

--- a/ivy/libraries.properties
+++ b/ivy/libraries.properties
@@ -60,3 +60,5 @@ slf4j-api.version=1.6.1
 slf4j-log4j12.version=1.6.1
 velocity.version=1.5
 zookeeper.version=3.4.3
+jdeb.version=0.11
+

--- a/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveBaseResultSet.java
+++ b/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveBaseResultSet.java
@@ -370,6 +370,16 @@ public abstract class HiveBaseResultSet implements ResultSet{
     return getObject(findColumn(columnName));
   }
 
+  public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+    // TODO method required by JDK 1.7
+    throw new SQLException("Method not supported");
+  }
+
+  public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+    // TODO method required by JDK 1.7
+    throw new SQLException("Method not supported");
+  }
+
   public Object getObject(int i, Map<String, Class<?>> map) throws SQLException {
     throw new SQLException("Method not supported");
   }

--- a/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveCallableStatement.java
+++ b/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveCallableStatement.java
@@ -462,6 +462,17 @@ public class HiveCallableStatement implements java.sql.CallableStatement {
     throw new SQLException("Method not supported");
   }
 
+  public <T> T getObject(int parameterIndex, Class<T> type) throws SQLException {
+    // TODO JDK 1.7
+     throw new SQLException("Method not supported");
+  }
+
+  public <T> T getObject(String parameterName, Class<T> type) throws SQLException {
+    // TODO JDK 1.7
+    throw new SQLException("Method not supported");
+  }
+
+
   /*
    * (non-Javadoc)
    * 
@@ -2030,6 +2041,16 @@ public class HiveCallableStatement implements java.sql.CallableStatement {
     // TODO Auto-generated method stub
     throw new SQLException("Method not supported");
   }
+
+  public void closeOnCompletion() throws SQLException {
+    // JDK 1.7
+    throw new SQLException("Method not supported");
+  }
+
+   public boolean isCloseOnCompletion() throws SQLException {
+     // JDK 1.7
+     throw new SQLException("Method not supported");
+   }
 
   /*
    * (non-Javadoc)

--- a/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveConnection.java
+++ b/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveConnection.java
@@ -29,6 +29,7 @@ import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+import java.util.concurrent.Executor;
 
 import java.sql.Array;
 import java.sql.Blob;
@@ -45,6 +46,7 @@ import java.sql.SQLXML;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Struct;
+import java.util.concurrent.*;
 import java.util.Map;
 import java.util.Properties;
 
@@ -119,6 +121,12 @@ public class HiveConnection implements java.sql.Connection {
     }
     isClosed = false;
     configureConnection();
+  }
+  
+ 
+  public void abort(Executor executor) throws SQLException {
+    // JDK 1.7
+    throw new SQLException("Method not supported");
   }
 
   private void configureConnection() throws SQLException {
@@ -340,6 +348,17 @@ public class HiveConnection implements java.sql.Connection {
     return new HiveDatabaseMetaData(client);
   }
 
+
+  public int getNetworkTimeout() throws SQLException {
+    // JDK 1.7
+    throw new SQLException("Method not supported");
+  }
+
+
+  public String getSchema() throws SQLException {
+    // JDK 1.7
+    throw new SQLException("Method not supported");
+  }
   /*
    * (non-Javadoc)
    * 
@@ -607,6 +626,11 @@ public class HiveConnection implements java.sql.Connection {
     throw new SQLException("Method not supported");
   }
 
+  public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+    // JDK 1.7
+    throw new SQLException("Method not supported");
+  }
+
   /*
    * (non-Javadoc)
    * 
@@ -637,6 +661,11 @@ public class HiveConnection implements java.sql.Connection {
 
   public Savepoint setSavepoint(String name) throws SQLException {
     // TODO Auto-generated method stub
+    throw new SQLException("Method not supported");
+  }
+
+  public void setSchema(String schema) throws SQLException {
+    // JDK 1.7
     throw new SQLException("Method not supported");
   }
 
@@ -673,15 +702,9 @@ public class HiveConnection implements java.sql.Connection {
     throw new SQLException("Method not supported");
   }
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see java.sql.Wrapper#unwrap(java.lang.Class)
-   */
-
   public <T> T unwrap(Class<T> iface) throws SQLException {
     // TODO Auto-generated method stub
     throw new SQLException("Method not supported");
   }
-
 }
+

--- a/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveDataSource.java
+++ b/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveDataSource.java
@@ -21,8 +21,12 @@ package org.apache.hadoop.hive.jdbc;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
 
 import javax.sql.DataSource;
+
+import java.util.logging.Logger;
 
 /**
  * HiveDataSource.
@@ -90,6 +94,12 @@ public class HiveDataSource implements DataSource {
    * @see javax.sql.CommonDataSource#setLogWriter(java.io.PrintWriter)
    */
 
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    // JDK 1.7
+    throw new SQLFeatureNotSupportedException("Method not supported");
+  }
+
+
   public void setLogWriter(PrintWriter arg0) throws SQLException {
     // TODO Auto-generated method stub
     throw new SQLException("Method not supported");
@@ -129,3 +139,4 @@ public class HiveDataSource implements DataSource {
   }
 
 }
+

--- a/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveDatabaseMetaData.java
+++ b/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveDatabaseMetaData.java
@@ -124,6 +124,18 @@ public class HiveDatabaseMetaData implements java.sql.DatabaseMetaData {
             return false;
           }
         }
+
+        public <T> T getObject(String columnLabel, Class<T> type)
+            throws SQLException {
+          // JDK 1.7  
+          throw new SQLException("Method not supported");
+        }
+
+        public <T> T getObject(int columnIndex, Class<T> type)
+            throws SQLException {
+          // JDK 1.7  
+          throw new SQLException("Method not supported");
+        }
       };
     } catch (Exception e) {
       throw new SQLException(e);
@@ -138,6 +150,17 @@ public class HiveDatabaseMetaData implements java.sql.DatabaseMetaData {
       String table, String columnNamePattern) throws SQLException {
     throw new SQLException("Method not supported");
   }
+
+  public ResultSet getPseudoColumns(String catalog, String schemaPattern, 
+       String tableNamePattern, String columnNamePattern) throws SQLException {
+    throw new SQLException("Method not supported");
+  }
+
+  public boolean generatedKeyAlwaysReturned() throws SQLException {
+    // JDK 1.7
+    throw new SQLException("Method not supported");
+  }
+
 
   /**
    * Convert a pattern containing JDBC catalog search wildcards into
@@ -255,6 +278,18 @@ public class HiveDatabaseMetaData implements java.sql.DatabaseMetaData {
           } else {
             return false;
           }
+        }
+
+        public <T> T getObject(String columnLabel, Class<T> type)
+            throws SQLException {
+          // JDK 1.7  
+          throw new SQLException("Method not supported");
+        }
+
+        public <T> T getObject(int columnIndex, Class<T> type)
+            throws SQLException {
+          // JDK 1.7  
+          throw new SQLException("Method not supported");
         }
       };
     } catch (Exception e) {
@@ -514,6 +549,18 @@ public class HiveDatabaseMetaData implements java.sql.DatabaseMetaData {
       public boolean next() throws SQLException {
         return false;
       }
+
+      public <T> T getObject(String columnLabel, Class<T> type)
+          throws SQLException {
+        // JDK 1.7  
+        throw new SQLException("Method not supported");
+      }
+
+      public <T> T getObject(int columnIndex, Class<T> type)
+          throws SQLException {
+        // JDK 1.7  
+        throw new SQLException("Method not supported");
+      }
     };
 
   }
@@ -562,6 +609,18 @@ public class HiveDatabaseMetaData implements java.sql.DatabaseMetaData {
         } else {
           return false;
         }
+      }
+
+      public <T> T getObject(String columnLabel, Class<T> type)
+          throws SQLException {
+        // JDK 1.7  
+        throw new SQLException("Method not supported");
+      }
+
+      public <T> T getObject(int columnIndex, Class<T> type)
+          throws SQLException {
+        // JDK 1.7  
+        throw new SQLException("Method not supported");
       }
     };
     return result;
@@ -630,6 +689,18 @@ public class HiveDatabaseMetaData implements java.sql.DatabaseMetaData {
         }
       }
 
+      public <T> T getObject(String columnLabel, Class<T> type)
+          throws SQLException {
+        // JDK 1.7  
+        throw new SQLException("Method not supported");
+      }
+
+      public <T> T getObject(int columnIndex, Class<T> type)
+          throws SQLException {
+        // JDK 1.7  
+        throw new SQLException("Method not supported");
+      }
+
     };
     return result;
   }
@@ -688,6 +759,18 @@ public class HiveDatabaseMetaData implements java.sql.DatabaseMetaData {
 
       public boolean next() throws SQLException {
         return false;
+      }
+
+      public <T> T getObject(String columnLabel, Class<T> type)
+          throws SQLException {
+        // JDK 1.7  
+        throw new SQLException("Method not supported");
+      }
+
+      public <T> T getObject(int columnIndex, Class<T> type)
+          throws SQLException {
+        // JDK 1.7  
+        throw new SQLException("Method not supported");
       }
     };
   }
@@ -1086,4 +1169,6 @@ public class HiveDatabaseMetaData implements java.sql.DatabaseMetaData {
     System.out.println("DriverName: " + meta.getDriverName());
     System.out.println("DriverVersion: " + meta.getDriverVersion());
   }
+
 }
+

--- a/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
+++ b/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveDriver.java
@@ -24,9 +24,11 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 /**
@@ -166,6 +168,11 @@ public class HiveDriver implements Driver {
     return HiveDriver.getMinorDriverVersion();
   }
 
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    // JDK 1.7
+    throw new SQLFeatureNotSupportedException("Method not supported");
+  }
+
   public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
     if (info == null) {
       info = new Properties();
@@ -294,4 +301,6 @@ public class HiveDriver implements Driver {
     }
     return manifestAttributes.getValue(attributeName);
   }
+
 }
+

--- a/jdbc/src/java/org/apache/hadoop/hive/jdbc/HivePreparedStatement.java
+++ b/jdbc/src/java/org/apache/hadoop/hive/jdbc/HivePreparedStatement.java
@@ -844,6 +844,12 @@ public class HivePreparedStatement implements PreparedStatement {
      warningChain=null;
   }
 
+
+  public void closeOnCompletion() throws SQLException {
+    // JDK 1.7
+    throw new SQLException("Method not supported");
+  }
+
   /**
    *  Closes the prepared statement.
    *
@@ -1139,6 +1145,11 @@ public class HivePreparedStatement implements PreparedStatement {
   public boolean isClosed() throws SQLException {
     return isClosed;
   }
+
+   public boolean isCloseOnCompletion() throws SQLException {
+     //JDK 1.7
+     throw new SQLException("Method not supported");
+   }
 
   /*
    * (non-Javadoc)

--- a/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveQueryResultSet.java
+++ b/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveQueryResultSet.java
@@ -190,6 +190,16 @@ public class HiveQueryResultSet extends HiveBaseResultSet {
     return fetchSize;
   }
 
+  public <T> T getObject(String columnLabel, Class<T> type)  throws SQLException {
+    //JDK 1.7
+        throw new SQLException("Method not supported");
+  }
+
+  public <T> T getObject(int columnIndex, Class<T> type)  throws SQLException {
+    //JDK 1.7
+        throw new SQLException("Method not supported");
+  }
+
   /**
    * Convert a LazyObject to a standard Java object in compliance with JDBC 3.0 (see JDBC 3.0
    * Specification, Table B-3: Mapping from JDBC Types to Java Object Types).
@@ -207,4 +217,6 @@ public class HiveQueryResultSet extends HiveBaseResultSet {
 
     return obj;
   }
+
 }
+

--- a/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveStatement.java
+++ b/jdbc/src/java/org/apache/hadoop/hive/jdbc/HiveStatement.java
@@ -117,6 +117,11 @@ public class HiveStatement implements java.sql.Statement {
     isClosed = true;
   }
 
+  public void closeOnCompletion() throws SQLException {
+     // JDK 1.7
+     throw new SQLException("Method not supported");
+  }
+
   /*
    * (non-Javadoc)
    * 
@@ -398,6 +403,11 @@ public class HiveStatement implements java.sql.Statement {
 
   public boolean isClosed() throws SQLException {
     return isClosed;
+  }
+
+  public boolean isCloseOnCompletion() throws SQLException {
+    // JDK 1.7
+    throw new SQLException("Method not supported");
   }
 
   /*


### PR DESCRIPTION
Two fixes (Hive trunk patches still under review but hopefully we can get this into the shark-0.9 branch sooner): fix annoying JDK7 Hive JDBC build problems, and add a target to build a Debian package (we need that to deploy the Shark-customized version of Hive). The goal is to get all these patches into the official Hive trunk and 0.9 branch as well, of course.
