### PR TITLE
Explicitly set javac's source and target versions

### DIFF
--- a/ant/build.xml
+++ b/ant/build.xml
@@ -35,6 +35,8 @@ to call at top-level: ant deploy-contrib compile-core-test
      includes="**/*.java"
      destdir="${build.classes}"
      debug="${javac.debug}"
+     target="${javac.version}"
+     source="${javac.version}"
      deprecation="${javac.deprecation}">
       <compilerarg line="${javac.args} ${javac.args.warnings}" />
       <classpath refid="classpath"/>

--- a/build-common.xml
+++ b/build-common.xml
@@ -249,6 +249,8 @@
      destdir="${build.classes}"
      debug="${javac.debug}"
      deprecation="${javac.deprecation}"
+     target="${javac.version}"
+     source="${javac.version}"
      includeantruntime="false">
       <compilerarg line="${javac.args} ${javac.args.warnings}" />
       <classpath refid="classpath"/>

--- a/cli/build.xml
+++ b/cli/build.xml
@@ -35,6 +35,8 @@ to call at top-level: ant deploy-contrib compile-core-test
      includes="**/*.java"
      destdir="${build.classes}"
      debug="${javac.debug}"
+     target="${javac.version}"
+     source="${javac.version}"
      deprecation="${javac.deprecation}"
      includeantruntime="false">
       <compilerarg line="${javac.args} ${javac.args.warnings}" />

--- a/common/build.xml
+++ b/common/build.xml
@@ -35,6 +35,8 @@ to call at top-level: ant deploy-contrib compile-core-test
      includes="**/*.java"
      destdir="${build.classes}"
      debug="${javac.debug}"
+     target="${javac.version}"
+     source="${javac.version}"
      deprecation="${javac.deprecation}"
      includeantruntime="false">
       <compilerarg line="${javac.args} ${javac.args.warnings}" />

--- a/hwi/build.xml
+++ b/hwi/build.xml
@@ -64,6 +64,8 @@
      includes="**/*.java"
      destdir="${build.classes}"
      debug="${javac.debug}"
+     target="${javac.version}"
+     source="${javac.version}"
      deprecation="${javac.deprecation}">
       <compilerarg line="${javac.args} ${javac.args.warnings}" />
       <classpath refid="classpath"/>

--- a/jdbc/build.xml
+++ b/jdbc/build.xml
@@ -42,6 +42,8 @@
         includes="**/*.java"
         destdir="${build.classes}"
         debug="${javac.debug}"
+        target="${javac.version}"
+        source="${javac.version}"
         deprecation="${javac.deprecation}"
         includeantruntime="false"
         >

--- a/metastore/build.xml
+++ b/metastore/build.xml
@@ -59,6 +59,8 @@
      includes="**/*.java"
      destdir="${build.classes}"
      debug="${javac.debug}"
+     target="${javac.version}"
+     source="${javac.version}"
      deprecation="${javac.deprecation}"
      includeantruntime="false">
       <classpath refid="classpath"/>
@@ -75,6 +77,8 @@
         srcdir="${model.dir}"
         destdir="${build.classes}"
         debug="${javac.debug}"
+        target="${javac.version}"
+        source="${javac.version}"
         includeantruntime="false">
        <classpath refid="classpath"/>
     </javac>

--- a/pdk/build.xml
+++ b/pdk/build.xml
@@ -36,6 +36,8 @@
      destdir="${build.classes}"
      debug="${javac.debug}"
      deprecation="${javac.deprecation}"
+     target="${javac.version}"
+     source="${javac.version}"
      includeantruntime="false">
       <compilerarg line="${javac.args} ${javac.args.warnings}" />
       <classpath refid="classpath-pdk"/>

--- a/pdk/scripts/build-plugin.xml
+++ b/pdk/scripts/build-plugin.xml
@@ -64,6 +64,8 @@
        srcdir="${src.dir}"
        includes="**/*.java"
        includeantruntime="false"
+       target="${javac.version}"
+       source="${javac.version}"
        destdir="${build.classes}">
       <classpath refid="plugin.classpath"/>
     </javac>

--- a/ql/build.xml
+++ b/ql/build.xml
@@ -157,6 +157,8 @@
      includes="**/*.java"
      destdir="${build.classes}"
      debug="${javac.debug}"
+     target="${javac.version}"
+     source="${javac.version}"
      deprecation="${javac.deprecation}"
      includeantruntime="false">
       <compilerarg line="${javac.args} ${javac.args.warnings}" />

--- a/serde/build.xml
+++ b/serde/build.xml
@@ -44,6 +44,8 @@
      srcdir="${src.dir}/java/:${src.dir}/gen/thrift/gen-javabean/:${src.dir}/gen/protobuf/gen-java/"
      destdir="${build.classes}"
      debug="${javac.debug}"
+     target="${javac.version}"
+     source="${javac.version}"
      deprecation="${javac.deprecation}"
      includeantruntime="false">
       <compilerarg line="${javac.args} ${javac.args.warnings}" />

--- a/service/build.xml
+++ b/service/build.xml
@@ -39,6 +39,8 @@
      includes="**/*.java"
      destdir="${build.classes}"
      debug="${javac.debug}"
+     target="${javac.version}"
+     source="${javac.version}"
      deprecation="${javac.deprecation}"
      includeantruntime="false">
       <classpath refid="classpath"/>

--- a/shims/build.xml
+++ b/shims/build.xml
@@ -77,6 +77,8 @@ to call at top-level: ant deploy-contrib compile-core-test
      includes="**/*.java"
      destdir="${build.classes}"
      debug="${javac.debug}"
+     target="${javac.version}"
+     source="${javac.version}"
      deprecation="${javac.deprecation}"
      srcdir="${sources}"
      includeantruntime="false">


### PR DESCRIPTION
This patch explicitly specifies the `-source` and `-target` versions for `javac` to avoid the following problem under JDK7:

```
jey@domU-12-31-39-18-35-54:~/work/hive$ build/dist/bin/hive 
WARNING: org.apache.hadoop.metrics.jvm.EventCounter is deprecated. Please use org.apache.hadoop.log.metrics.EventCounter in all the log4j.properties files.
Logging initialized using configuration in jar:file:/data/jey/work/hive/build/dist/lib/hive-common-0.9.0-amplab-3.jar!/hive-log4j.properties
Hive history file=/tmp/jey/hive_job_log_jey_201304171336_1637246376.txt
hive> create table src(key int, value string);
java.lang.VerifyError: Expecting a stackmap frame at branch target 40 in method org.apache.hadoop.hive.metastore.model.MDatabase.jdoGetparameters(Lorg/apache/hadoop/hive/metastore/model/MDatabase;)Ljava/util/Map; at offset 4
        at java.lang.Class.getDeclaredFields0(Native Method)
        at java.lang.Class.privateGetDeclaredFields(Class.java:2317)
        at java.lang.Class.getDeclaredFields(Class.java:1762)
        at org.datanucleus.metadata.ClassMetaData.addMetaDataForMembersNotInMetaData(ClassMetaData.java:358)
        at org.datanucleus.metadata.ClassMetaData.populate(ClassMetaData.java:199)
        at org.datanucleus.metadata.MetaDataManager$1.run(MetaDataManager.java:2394)
        at java.security.AccessController.doPrivileged(Native Method)
        at org.datanucleus.metadata.MetaDataManager.populateAbstractClassMetaData(MetaDataManager.java:2388)
        at org.datanucleus.metadata.MetaDataManager.populateFileMetaData(MetaDataManager.java:2225)
        at org.datanucleus.jdo.metadata.JDOMetaDataManager.loadMetaDataForClass(JDOMetaDataManager.java:732)
        at org.datanucleus.jdo.metadata.JDOMetaDataManager.getMetaDataForClassInternal(JDOMetaDataManager.java:353)
        at org.datanucleus.metadata.MetaDataManager.getMetaDataForClass(MetaDataManager.java:1202)
        at org.datanucleus.ObjectManagerImpl.hasPersistenceInformationForClass(ObjectManagerImpl.java:4366)
        at org.datanucleus.ObjectManagerImpl.assertClassPersistable(ObjectManagerImpl.java:4284)
        at org.datanucleus.ObjectManagerImpl.getExtent(ObjectManagerImpl.java:4147)
        at org.datanucleus.store.rdbms.query.legacy.JDOQLQueryCompiler.compileCandidates(JDOQLQueryCompiler.java:411)
        at org.datanucleus.store.rdbms.query.legacy.QueryCompiler.executionCompile(QueryCompiler.java:312)
        at org.datanucleus.store.rdbms.query.legacy.JDOQLQueryCompiler.compile(JDOQLQueryCompiler.java:225)
        at org.datanucleus.store.rdbms.query.legacy.JDOQLQuery.compileInternal(JDOQLQuery.java:175)
        at org.datanucleus.store.query.Query.executeQuery(Query.java:1628)
        at org.datanucleus.store.rdbms.query.legacy.JDOQLQuery.executeQuery(JDOQLQuery.java:245)
        at org.datanucleus.store.query.Query.executeWithArray(Query.java:1499)
        at org.datanucleus.jdo.JDOQuery.execute(JDOQuery.java:243)
        at org.apache.hadoop.hive.metastore.ObjectStore.getMDatabase(ObjectStore.java:389)
        at org.apache.hadoop.hive.metastore.ObjectStore.getDatabase(ObjectStore.java:408)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:601)
        at org.apache.hadoop.hive.metastore.RetryingRawStore.invoke(RetryingRawStore.java:111)
        at sun.proxy.$Proxy5.getDatabase(Unknown Source)
        at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.createDefaultDB_core(HiveMetaStore.java:351)
        at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.createDefaultDB(HiveMetaStore.java:371)
        at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.init(HiveMetaStore.java:278)
        at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.<init>(HiveMetaStore.java:248)
        at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.<init>(HiveMetaStoreClient.java:114)
        at org.apache.hadoop.hive.ql.metadata.Hive.createMetaStoreClient(Hive.java:2092)
        at org.apache.hadoop.hive.ql.metadata.Hive.getMSC(Hive.java:2102)
        at org.apache.hadoop.hive.ql.metadata.Hive.createTable(Hive.java:538)
        at org.apache.hadoop.hive.ql.exec.DDLTask.createTable(DDLTask.java:3313)
        at org.apache.hadoop.hive.ql.exec.DDLTask.execute(DDLTask.java:242)
        at org.apache.hadoop.hive.ql.exec.Task.executeTask(Task.java:134)
        at org.apache.hadoop.hive.ql.exec.TaskRunner.runSequential(TaskRunner.java:57)
        at org.apache.hadoop.hive.ql.Driver.launchTask(Driver.java:1312)
        at org.apache.hadoop.hive.ql.Driver.execute(Driver.java:1104)
        at org.apache.hadoop.hive.ql.Driver.run(Driver.java:937)
        at org.apache.hadoop.hive.cli.CliDriver.processLocalCmd(CliDriver.java:258)
        at org.apache.hadoop.hive.cli.CliDriver.processCmd(CliDriver.java:215)
        at org.apache.hadoop.hive.cli.CliDriver.processLine(CliDriver.java:406)
        at org.apache.hadoop.hive.cli.CliDriver.run(CliDriver.java:689)
        at org.apache.hadoop.hive.cli.CliDriver.main(CliDriver.java:557)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:601)
        at org.apache.hadoop.util.RunJar.main(RunJar.java:156)
FAILED: Execution Error, return code -101 from org.apache.hadoop.hive.ql.exec.DDLTask
```
