### PR TITLE
remove HiveConf and Configuration from thread-local after conection to h...

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -163,7 +163,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
 
     // Thread local configuration is needed as many threads could make changes
     // to the conf using the connection hook
-    private final ThreadLocal<Configuration> threadLocalConf =
+    private static final ThreadLocal<Configuration> threadLocalConf =
       new ThreadLocal<Configuration>() {
         @Override
         protected synchronized Configuration initialValue() {
@@ -317,6 +317,11 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         threadLocalConf.set(conf);
       }
       return conf;
+    }
+
+    public static void cleanThreadLocal() {
+      threadLocalConf.remove();
+      LOG.debug("removed current Configuration instance from thread-local var");
     }
 
     /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -63,7 +63,6 @@ import org.apache.hadoop.hive.metastore.api.HiveObjectPrivilege;
 import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
 import org.apache.hadoop.hive.metastore.api.HiveObjectType;
 import org.apache.hadoop.hive.metastore.api.Index;
-import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
@@ -178,6 +177,7 @@ public class Hive {
 
   public static void closeCurrent() {
     hiveDB.remove();
+    LOG.debug("removed current metastore.Hive instance from thread-local var");
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -748,4 +748,10 @@ public class SessionState {
   public void setLocalMapRedErrors(Map<String, List<String>> localMapRedErrors) {
     this.localMapRedErrors = localMapRedErrors;
   }
+
+  public static void cleanThreadLocal() {
+    tss.remove();
+    Log LOG = LogFactory.getLog(SessionState.class.getName());
+    LOG.debug("removed current SessionState instance from thread-local var");
+  }
 }

--- a/service/src/java/org/apache/hadoop/hive/service/HiveServer.java
+++ b/service/src/java/org/apache/hadoop/hive/service/HiveServer.java
@@ -34,9 +34,9 @@ import java.util.Properties;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.hive.common.ServerUtils;
 import org.apache.hadoop.hive.common.LogUtils;
 import org.apache.hadoop.hive.common.LogUtils.LogInitializationException;
+import org.apache.hadoop.hive.common.ServerUtils;
 import org.apache.hadoop.hive.common.cli.CommonCliOptions;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;
@@ -44,6 +44,7 @@ import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Schema;
 import org.apache.hadoop.hive.ql.CommandNeedRetryException;
 import org.apache.hadoop.hive.ql.Driver;
+import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.plan.api.QueryPlan;
 import org.apache.hadoop.hive.ql.processors.CommandProcessor;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorFactory;
@@ -61,8 +62,7 @@ import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TServerTransport;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportFactory;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
+
 import com.facebook.fb303.fb_status;
 
 /**
@@ -227,6 +227,9 @@ public class HiveServer extends ThriftHive {
       if (session.getTmpOutputFile() != null) {
         session.getTmpOutputFile().delete();
       }
+      SessionState.cleanThreadLocal();
+      Hive.closeCurrent();
+      HiveMetaStore.HMSHandler.cleanThreadLocal();
       pipeIn = null;
     }
 


### PR DESCRIPTION
...iveserver is closed. I was done to clean sharkserver memory after all clients connections are closed. Without this fix I see about 200 HiveConf and about 200 hadoop Configuration instances in sharkserver memory even if all connections are closed and server is idle for a long time. HiveConf and Confugiration are quite large instances - about 100-150KB each. Totally they use about 40-60 MB of memory
before:
![1000con-2](https://f.cloud.github.com/assets/218087/1031368/e275d43a-0edc-11e3-8c86-d657a1d0dece.png)
after:
![threadlocal-3 -fixes](https://f.cloud.github.com/assets/218087/1031369/f47a3194-0edc-11e3-948d-d791097e02a3.png)
