### PR TITLE
Keywrapper fix

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/KeyWrapper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/KeyWrapper.java
@@ -22,9 +22,9 @@ import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 
 public abstract class KeyWrapper {
-  abstract void getNewKey(Object row, ObjectInspector rowInspector) throws HiveException;
-  abstract void setHashKey();
-  abstract KeyWrapper copyKey();
-  abstract void copyKey(KeyWrapper oldWrapper);
-  abstract Object[] getKeyArray();
+  public abstract void getNewKey(Object row, ObjectInspector rowInspector) throws HiveException;
+  public abstract void setHashKey();
+  public abstract KeyWrapper copyKey();
+  public abstract void copyKey(KeyWrapper oldWrapper);
+  public abstract Object[] getKeyArray();
 }


### PR DESCRIPTION
KeyWrapper in Hive is the package scope access restriction, which prevents the access from the object instances created by different classloader, even the caller has the same package name with KeyWrapper. 

The links may help in understanding.
https://access.redhat.com/site/documentation/en-US/JBoss_Enterprise_Application_Platform/4.3/html/Server_Configuration_Guide/Class_Loading_and_Types_in_Java-IllegalAccessException___Doing_what_you_should_not.html
