### PR TITLE
Check for null in Hive History

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/history/HiveHistory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/history/HiveHistory.java
@@ -416,6 +416,9 @@ public class HiveHistory {
   public void printRowCount(String queryId) {
     QueryInfo ji = queryInfoMap.get(queryId);
     synchronized(ji) {
+    	if (ji == null) {
+    		return;
+    	}
 	    for (String tab : ji.rowCountMap.keySet()) {
 	      console.printInfo(ji.rowCountMap.get(tab) + " Rows loaded to " + tab);
 	    }

--- a/ql/src/java/org/apache/hadoop/hive/ql/history/HiveHistory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/history/HiveHistory.java
@@ -415,10 +415,10 @@ public class HiveHistory {
 
   public void printRowCount(String queryId) {
     QueryInfo ji = queryInfoMap.get(queryId);
+    if (ji == null) {
+      return;
+    }
     synchronized(ji) {
-    	if (ji == null) {
-    		return;
-    	}
 	    for (String tab : ji.rowCountMap.keySet()) {
 	      console.printInfo(ji.rowCountMap.get(tab) + " Rows loaded to " + tab);
 	    }
@@ -432,10 +432,10 @@ public class HiveHistory {
    */
   public void endQuery(String queryId) {
     QueryInfo ji = queryInfoMap.get(queryId);
+    if (ji == null) {
+      return;
+    }
     synchronized(ji) {
-	    if (ji == null) {
-	      return;
-	    }
 	    log(RecordTypes.QueryEnd, ji.hm);
     }
     queryInfoMap.remove(queryId);


### PR DESCRIPTION
I think there may be some bigger underlying bug here -- that printRowCount() shouldn't be called before the corresponding QueryInfo has been created, or maybe two concurrent queries are using the same queryId, so the QueryInfo is getting deleted prematurely (because two queries are sharing one).  In any case, this makes the printRowCount() method consistent with other methods in this class, that check if the queryinfo is null before doing anything with it.
