### PR TITLE
SHARK-172 - Make ppd2 unit test pass

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ReduceSinkDeDuplication.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ReduceSinkDeDuplication.java
@@ -365,6 +365,7 @@ public class ReduceSinkDeDuplication implements Transform{
       if (result[0] > 0) {
         ArrayList<ExprNodeDesc> childKCs = cRS.getConf().getKeyCols();
         pRS.getConf().setKeyCols(ExprNodeDescUtils.backtrack(childKCs, cRS, pRS));
+        pRS.getConf().setNumDistributionKeys(cRS.getConf().getNumDistributionKeys());
       }
       if (result[1] > 0) {
         ArrayList<ExprNodeDesc> childPCs = cRS.getConf().getPartitionCols();


### PR DESCRIPTION
During Operator.initEvaluators() execution, the number of evaluators that get initialised for ReduceSinkOperators relates directly to the numDistributionKeys field.  Prior to this change, the number of elements in the keyCols array and the value of numDistributionKeys were potentially out of sync which would cause one of the ExprNodeColumnEvaluator's to have null fields and therefore throw a NPE during the ppd2 test run.

I've piggy backed this on the decision to copy across ExprNodeDesc's due to the direct link between that array and numDistributionKeys during Operator.initEvaluators() execution.
