### PR TITLE
Fix Shark build break.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ReduceSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ReduceSinkOperator.java
@@ -210,6 +210,14 @@ public class ReduceSinkOperator extends TerminalOperator<ReduceSinkDesc>
     return ObjectInspectorFactory.getStandardStructObjectInspector(outputColNames, sois );
   }
 
+  protected static StructObjectInspector initEvaluatorsAndReturnStruct(
+      ExprNodeEvaluator[] evals, List<List<Integer>> distinctColIndices,
+      List<String> outputColNames,
+      int length, ObjectInspector rowInspector) throws HiveException {
+    return initEvaluatorsAndReturnStruct(evals, distinctColIndices, outputColNames, length,
+      rowInspector, false, null);
+  }
+
   @Override
   public void processOp(Object row, int tag) throws HiveException {
     try {


### PR DESCRIPTION
PR #39 changed the signature of ReduceSinkOperator.initEvaluatorsAndReturnStruct(), while
shark/execution/ReduceSinkOperatorHelper.java dependes on it.
