### PR TITLE
provide real column names instead of internal ones

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -4227,7 +4227,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         }
 
         first = false;
-        cols = cols.concat(colInfo.getInternalName());
+        cols = cols.concat(colInfo.getAlias());
 
         // Replace VOID type with string when the output is a temp table or
         // local files.


### PR DESCRIPTION
This is used in Shark logging to show human-readable column names.
