### PR TITLE
Compile with JDK 1.6

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -202,8 +202,8 @@ class MetaStoreDirectSql {
       part.setValues(new ArrayList<String>());
       part.setDbName(dbName);
       part.setTableName(tblName);
-      if (fields[4] != null) part.setCreateTime((int)(long)fields[4]);
-      if (fields[5] != null) part.setLastAccessTime((int)(long)fields[5]);
+      if (fields[4] != null) part.setCreateTime((Integer)fields[4]);
+      if (fields[5] != null) part.setLastAccessTime((Integer)fields[5]);
       partitions.put(partitionId, part);
 
       // We assume each partition has an unique SD.
@@ -224,7 +224,7 @@ class MetaStoreDirectSql {
       tmpBoolean = extractSqlBoolean(fields[8]);
       if (tmpBoolean != null) sd.setStoredAsSubDirectories(tmpBoolean);
       sd.setLocation((String)fields[9]);
-      if (fields[10] != null) sd.setNumBuckets((int)(long)fields[10]);
+      if (fields[10] != null) sd.setNumBuckets((Integer)fields[10]);
       sd.setOutputFormat((String)fields[11]);
       sdSb.append(sdId).append(",");
       part.setSd(sd);


### PR DESCRIPTION
Reverts some of f6c52ddb7575d4324da296976d2d8f9535228b94

It looks like conversions using Long/Int objects should work. Please confirm on your end if so and submit another PR for the fix
