### PR TITLE
Some changes to build files for pushing to Sonatype/Maven Central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ common/src/gen
 *.iml
 *.ipr
 *.iws
-
+*.asc

--- a/build.properties
+++ b/build.properties
@@ -16,7 +16,7 @@
 
 Name=Hive
 name=hive
-version=0.11.0-shark-SNAPSHOT
+version=0.11.0-shark
 year=2012
 
 javac.debug=on

--- a/build.properties
+++ b/build.properties
@@ -126,8 +126,8 @@ mvn.publish.repo=snapshots
 mvn.jar.dir=${build.dir.hive}/maven/jars
 mvn.pom.dir=${build.dir.hive}/maven/poms
 mvn.license.dir=${build.dir.hive}/maven/licenses
-mvn.deploy.id=apache.snapshots.https
-mvn.deploy.url=https://repository.apache.org/content/repositories/snapshots
+mvn.deploy.id=sonatype-nexus-snapshots
+mvn.deploy.url=https://oss.sonatype.org/content/repositories/snapshots
 #
 # unit test Properties
 #
@@ -150,4 +150,3 @@ junit.jvm.args=-XX:-UseSplitVerifier -XX:+CMSClassUnloadingEnabled -XX:MaxPermSi
 
 # JVM arguments for Eclipse launch configurations
 eclipse.launch.jvm.args=-Xms256m -Xmx1024m ${jvm.args}
-

--- a/build.xml
+++ b/build.xml
@@ -1357,8 +1357,8 @@
         output.file="${mvn.jar.dir}/hive-metastore-${version}.jar.asc"
         gpg.passphrase="${gpg.passphrase}"/>
     <sign-artifact
-        input.file="${mvn.jar.dir}/hive-metastore-${version}.pom"
-        output.file="${mvn.jar.dir}/hive-metastore-${version}.pom.asc"
+        input.file="${mvn.pom.dir}/hive-metastore-${version}.pom"
+        output.file="${mvn.pom.dir}/hive-metastore-${version}.pom.asc"
         gpg.passphrase="${gpg.passphrase}"/>
 
     <!-- hive-serde -->

--- a/build.xml
+++ b/build.xml
@@ -58,11 +58,14 @@
   <property name="checkstyle.build.dir" location="${build.dir.hive}/checkstyle"/>
   <property name="rat.build.dir" location="${build.dir.hive}/rat"/>
   <property name="md5sum.format" value="{0}  {1}"/>
-  <!-- Properties for maven repositories -->
-  <property name="mvn.staging.repo.id" value="apache.staging.https"/>
-  <property name="mvn.staging.repo.url"
-    value="https://repository.apache.org/service/local/staging/deploy/maven2" />
 
+  <!-- Properties for maven repositories -->
+  <property name="mvn.staging.repo.id" value="sonatype-nexus-staging"/>
+  <property name="mvn.staging.repo.url"
+    value="https://oss.sonatype.org/service/local/staging/deploy/maven2"/>
+    <!-- value="https://repository.apache.org/service/local/staging/deploy/maven2" /> -->
+  <!-- Don't attach timestamp suffix to SNAPSHOT artifacts -->
+  <property name="uniqueVersion" value="false"/>
 
   <condition property="is-offline" value="true" else="false">
     <isset property="offline"/>
@@ -1128,6 +1131,7 @@
   <!-- Deploy a single artifact to the maven repository -->
   <target name="maven-publish-artifact">
     <echo message="Project: ${ant.project.name}"/>
+    <echo message="Maven pom dir: ${mvn.pom.dir}"/>
     <artifact:pom
        file="${mvn.pom.dir}/hive-${hive.project}-${version}.pom"
        id="hive.project.pom" />
@@ -1149,7 +1153,7 @@
       <elseif>
         <equals arg1="${mvn.publish.repo}" arg2="local"/>
         <then>
-          <artifact:install 
+          <artifact:install
               file="${mvn.jar.dir}/hive-${hive.project}-${version}.jar">
             <pom refid="hive.project.pom" />
           </artifact:install>
@@ -1169,6 +1173,7 @@
   <target name="maven-publish" depends="init,mvn-taskdef,maven-sign"
           description="Publish Maven artifacts">
     <echo message="Project: ${ant.project.name}"/>
+    <echo message="MVN Publish Repo: ${mvn.publish.repo}"/>
     <antcall target="maven-publish-artifact">
       <param name="hive.project" value="anttasks" />
     </antcall>

--- a/hcatalog/build.properties
+++ b/hcatalog/build.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-hive.version=0.11.0-shark-SNAPSHOT
+hive.version=0.11.0-shark
 hcatalog.version=${hive.version}
 jar.name=${ant.project.name}-${hcatalog.version}.jar
 hcatalog.jar=${ant.project.name}-${hcatalog.version}.jar

--- a/hcatalog/core/pom.xml
+++ b/hcatalog/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>edu.berkeley.cs.shark</groupId>
         <artifactId>hcatalog</artifactId>
-        <version>0.11.0-shark-SNAPSHOT</version>
+        <version>0.11.0-shark</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>edu.berkeley.cs.shark</groupId>
         <artifactId>hcatalog</artifactId>
-        <version>0.11.0-shark-SNAPSHOT</version>
+        <version>0.11.0-shark</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hcatalog/pom.xml
+++ b/hcatalog/pom.xml
@@ -45,7 +45,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>edu.berkeley.cs.shark</groupId>
   <artifactId>hcatalog</artifactId>
-  <version>0.11.0-shark-SNAPSHOT</version>
+  <version>0.11.0-shark</version>
   <packaging>pom</packaging>
 
   <build>

--- a/hcatalog/server-extensions/pom.xml
+++ b/hcatalog/server-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>edu.berkeley.cs.shark</groupId>
         <artifactId>hcatalog</artifactId>
-        <version>0.11.0-shark-SNAPSHOT</version>
+        <version>0.11.0-shark</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hcatalog/storage-handlers/hbase/pom.xml
+++ b/hcatalog/storage-handlers/hbase/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>edu.berkeley.cs.shark</groupId>
     <artifactId>hcatalog</artifactId>
-    <version>0.11.0-shark-SNAPSHOT</version>
+    <version>0.11.0-shark</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hcatalog/webhcat/java-client/pom.xml
+++ b/hcatalog/webhcat/java-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>edu.berkeley.cs.shark</groupId>
         <artifactId>hcatalog</artifactId>
-        <version>0.11.0-shark-SNAPSHOT</version>
+        <version>0.11.0-shark</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/hcatalog/webhcat/svr/pom.xml
+++ b/hcatalog/webhcat/svr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>edu.berkeley.cs.shark</groupId>
         <artifactId>hcatalog</artifactId>
-        <version>0.11.0-shark-SNAPSHOT</version>
+        <version>0.11.0-shark</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Uses edu.berkeley.amplab for now. This works in conjunction with https://github.com/amplab/shark/pull/271
