### PR TITLE
Don't publish hcatalog, since it is not built

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1205,29 +1205,6 @@
     <antcall target="maven-publish-artifact">
       <param name="hive.project" value="shims" />
     </antcall>
-
-    <!-- Handle HCat separately -->
-    <if>
-      <equals arg1="${mvn.publish.repo}" arg2="staging" />
-      <then>
-        <ant dir="hcatalog" target="mvn-deploy-signed">
-          <property name="mvn.deploy.repo.id" value="${mvn.staging.repo.id}"/>
-          <property name="mvn.deploy.repo.url" value="${mvn.staging.repo.url}"/>
-        </ant>
-      </then>
-      <elseif>
-        <equals arg1="${mvn.publish.repo}" arg2="local"/>
-        <then>
-          <!-- NOP, HCat always publishes to the local repo -->
-        </then>
-      </elseif>
-      <else>
-        <ant dir="hcatalog" target="mvn-deploy-signed">
-          <property name="mvn.deploy.repo.id" value="${mvn.deploy.id}"/>
-          <property name="mvn.deploy.repo.url" value="${mvn.deploy.url}"/>
-        </ant>
-      </else>
-    </if>
   </target>
 
   <target name="maven-sign" if="staging">


### PR DESCRIPTION
Since hcatalog build has been disabled, maven-publish should not publish it at all.
