### PR TITLE
bug fix : hive 0.11 inner join bug fix

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
@@ -116,6 +116,9 @@ public class HiveConnection implements java.sql.Connection {
     } else {
       // for remote JDBC client, try to set the conf var using 'set foo=bar'
       Statement stmt = createStatement();
+
+      stmt.execute("use " + connParams.getDbName());
+
       for (Entry<String, String> hiveConf : connParams.getHiveConfs().entrySet()) {
         stmt.execute("set " + hiveConf.getKey() + "=" + hiveConf.getValue());
         stmt.close();

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
@@ -401,9 +401,15 @@ public abstract class BaseSemanticAnalyzer {
     if (val == null) {
       return null;
     }
+	
     if (val.charAt(0) == '`' && val.charAt(val.length() - 1) == '`') {
       val = val.substring(1, val.length() - 1);
     }
+
+    if (val.charAt(0) == '"' && val.charAt(val.length() - 1) == '"') {
+      val = val.substring(1, val.length() - 1);
+    }
+	
     return val;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
@@ -172,8 +172,8 @@ tableSample
 tableSource
 @init { gParent.msgs.push("table source"); }
 @after { gParent.msgs.pop(); }
-    : tabname=tableName (ts=tableSample)? (alias=identifier)?
-    -> ^(TOK_TABREF $tabname $ts? $alias?)
+    : tabname=tableName (props=tableProperties)? (ts=tableSample)? (KW_AS? alias=Identifier)?
+    -> ^(TOK_TABREF $tabname $props? $ts? $alias?)
     ;
 
 tableName

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
@@ -183,6 +183,15 @@ tableName
     db=identifier DOT tab=identifier
     -> ^(TOK_TABNAME $db $tab)
     |
+    db=identifier DOT tab2=StringLiteral
+    -> ^(TOK_TABNAME $db Identifier[$tab2.text.substring(1,$tab2.text.length()-1)])
+    |
+    db2=StringLiteral DOT tab=identifier
+    -> ^(TOK_TABNAME Identifier[$db2.text.substring(1,$db2.text.length()-1)] $tab)
+    |
+    db2=StringLiteral DOT tab2=StringLiteral
+    -> ^(TOK_TABNAME Identifier[$db2.text.substring(1,$db2.text.length()-1)] Identifier[$tab2.text.substring(1,$tab2.text.length()-1)])
+    |
     tab=identifier
     -> ^(TOK_TABNAME $tab)
     ;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/HiveLexer.g
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/HiveLexer.g
@@ -295,6 +295,7 @@ BITWISEOR : '|';
 BITWISEXOR : '^';
 QUESTION : '?';
 DOLLAR : '$';
+DOUBLEQUOTE : '\"'
 
 // LITERALS
 fragment

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -2619,9 +2619,11 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         pos = genColListRegex(unescapeIdentifier(expr.getChild(0).getText()),
             null, expr, col_list, inputRR, pos, out_rwsch, qb.getAliases(), subQuery);
       } else if (expr.getType() == HiveParser.DOT
-          && expr.getChild(0).getType() == HiveParser.TOK_TABLE_OR_COL
+          && ((expr.getChild(0).getType() == HiveParser.TOK_TABLE_OR_COL
           && inputRR.hasTableAlias(unescapeIdentifier(expr.getChild(0)
-              .getChild(0).getText().toLowerCase())) && !hasAsClause
+              .getChild(0).getText().toLowerCase()))) || (expr.getChild(0).getType() == HiveParser.StringLiteral
+          && inputRR.hasTableAlias(unescapeIdentifier(expr.getChild(0).getText().toLowerCase()))) )
+          && !hasAsClause
           && !inputRR.getIsExprResolver()
           && isRegex(unescapeIdentifier(expr.getChild(1).getText()))) {
         // In case the expression is TABLE.COL (col can be regex).

--- a/service/src/java/org/apache/hive/service/cli/operation/GetCatalogsOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/GetCatalogsOperation.java
@@ -18,6 +18,8 @@
 
 package org.apache.hive.service.cli.operation;
 
+import java.util.List;
+
 import org.apache.hive.service.cli.FetchOrientation;
 import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.cli.OperationState;
@@ -46,6 +48,20 @@ public class GetCatalogsOperation extends MetadataOperation {
   @Override
   public void run() throws HiveSQLException {
     setState(OperationState.RUNNING);
+	try{
+		List<String> databaseNames = getParentSession().getMetaStoreClient().getAllDatabases();
+	
+		if(databaseNames != null && databaseNames.size() > 0){
+			for(String databaseName : databaseNames){
+				Object rowData[] = new Object[] {databaseName};
+				rowSet.addRow(RESULT_SET_SCHEMA, rowData);
+			}
+		}
+	} catch (Exception e) {
+      setState(OperationState.ERROR);
+      throw new HiveSQLException(e);
+    }
+	
     setState(OperationState.FINISHED);
   }
 

--- a/service/src/java/org/apache/hive/service/cli/operation/GetColumnsOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/GetColumnsOperation.java
@@ -140,7 +140,7 @@ public class GetColumnsOperation extends MetadataOperation {
               continue;
             }
             Object[] rowData = new Object[] {
-                null,  // TABLE_CAT
+                table.getDbName(),  // TABLE_CAT
                 table.getDbName(), // TABLE_SCHEM
                 table.getTableName(), // TABLE_NAME
                 column.getName(), // COLUMN_NAME

--- a/service/src/java/org/apache/hive/service/cli/operation/GetTablesOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/GetTablesOperation.java
@@ -59,6 +59,7 @@ public class GetTablesOperation extends MetadataOperation {
 	  typeMap = new HashMap<String, String>();
 	  
 	  typeMap.put("MANAGED_TABLE", "TABLE");
+	  typeMap.put("EXTERNAL_TABLE", "TABLE");
 	  typeMap.put("MANAGED_VIEW", "VIEW");
   }
 
@@ -91,11 +92,11 @@ public class GetTablesOperation extends MetadataOperation {
               dbName,
               table.getDbName(),
               table.getTableName(),
-              typeMap.get(table.getTableType()),
+              typeMap.containsKey(table.getTableType())? typeMap.get(table.getTableType()) : table.getTableType(),
               table.getParameters().get("comment")
               };
 
-          if (tableTypes.isEmpty() || tableTypes.contains( typeMap.get(table.getTableType()) )) {
+          if (tableTypes.isEmpty() || tableTypes.contains( (typeMap.containsKey(table.getTableType())? typeMap.get(table.getTableType()) : table.getTableType()) )) {
             rowSet.addRow(RESULT_SET_SCHEMA, rowData);
           }
         }

--- a/service/src/java/org/apache/hive/service/cli/operation/GetTablesOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/GetTablesOperation.java
@@ -20,6 +20,8 @@ package org.apache.hive.service.cli.operation;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -50,6 +52,15 @@ public class GetTablesOperation extends MetadataOperation {
   .addStringColumn("TABLE_NAME", "Table name.")
   .addStringColumn("TABLE_TYPE", "The table type, e.g. \"TABLE\", \"VIEW\", etc.")
   .addStringColumn("REMARKS", "Comments about the table.");
+  
+  private static Map<String, String> typeMap;
+  
+  static{
+	  typeMap = new HashMap<String, String>();
+	  
+	  typeMap.put("MANAGED_TABLE", "TABLE");
+	  typeMap.put("MANAGED_VIEW", "VIEW");
+  }
 
   protected GetTablesOperation(HiveSession parentSession,
       String catalogName, String schemaName, String tableName,
@@ -77,13 +88,14 @@ public class GetTablesOperation extends MetadataOperation {
         List<String> tableNames = metastoreClient.getTables(dbName, tablePattern);
         for (Table table : metastoreClient.getTableObjectsByName(dbName, tableNames)) {
           Object[] rowData = new Object[] {
-              DEFAULT_HIVE_CATALOG,
+              dbName,
               table.getDbName(),
               table.getTableName(),
-              table.getTableType(),
+              typeMap.get(table.getTableType()),
               table.getParameters().get("comment")
               };
-          if (tableTypes.isEmpty() || tableTypes.contains(table.getTableType())) {
+
+          if (tableTypes.isEmpty() || tableTypes.contains( typeMap.get(table.getTableType()) )) {
             rowSet.addRow(RESULT_SET_SCHEMA, rowData);
           }
         }


### PR DESCRIPTION
I think it is apache hive 0.11 bug.
When I try to query with inner join and no table alias, Hive 0.11 recognized 'INNER' as table alias.
It is not amp lab hive bug. But for shark, it need to be fixed.

sample query is like :
select foo.\* from foo inner join bar on (foo.f = bar.b)
